### PR TITLE
Enable public internet -> BIG-IP -> backend

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -125,9 +125,11 @@ module "configsync_fw" {
 # E.g. alias IP (VIP) migration on failover, route updates, etc.
 module "cfe_role" {
   source                   = "memes/f5-bigip/google//modules/cfe-role"
-  version = "2.1.0-rc1"
+  version = "2.1.0-rc5"
   target_type = "project"
   target_id   = var.project_id
+  random_id_prefix = format("student%d", var.student_id)
+  title = format("CFE role for student%d", var.student_id)
   members     = [format("serviceAccount:%s", local.bigip_service_account)]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -167,6 +167,8 @@ module "bigip_1" {
   gcp_secret_manager_authentication = true
   gcp_secret_name = format("student%d-bigip-admin-key", var.student_id)
   labels = local.cfe_labels
+  DO_URL = "https://github.com/F5Networks/f5-declarative-onboarding/releases/download/v1.20.0/f5-declarative-onboarding-1.20.0-2.noarch.rpm"
+
   mgmt_subnet_ids = [
     {
       subnet_id = data.google_compute_subnetwork.mgmt.self_link
@@ -202,6 +204,7 @@ module "bigip_2" {
   gcp_secret_manager_authentication = true
   gcp_secret_name = format("student%d-bigip-admin-key", var.student_id)
   labels = local.cfe_labels
+  DO_URL = "https://github.com/F5Networks/f5-declarative-onboarding/releases/download/v1.20.0/f5-declarative-onboarding-1.20.0-2.noarch.rpm"
   mgmt_subnet_ids = [
     {
       subnet_id = data.google_compute_subnetwork.mgmt.self_link

--- a/main.tf
+++ b/main.tf
@@ -316,25 +316,25 @@ resource "google_compute_firewall" "bigip_backend" {
   }
 }
 
-# Allow BIG-IP instances to reach backend services
-resource "google_compute_firewall" "admin_internal" {
+# Allow students to access external BIG-IP interfaces
+resource "google_compute_firewall" "public_ingress" {
   project       = var.project_id
-  name          = format("student%d-int-allow-admin-internal", var.student_id)
-  network       = data.google_compute_subnetwork.internal.network
-  description   = format("Allow BIG-IP to backend access on internal (student%d)", var.student_id)
+  name          = format("student%d-ext-allow-public-ingress", var.student_id)
+  network       = data.google_compute_subnetwork.external.network
+  description   = format("Allow public ingress to BIG-IP external (student%d)", var.student_id)
   direction     = "INGRESS"
   source_ranges = [
     "0.0.0.0/0",
   ]
+  target_service_accounts = [
+    local.bigip_service_account,
+  ]
   allow {
     protocol = "tcp"
     ports = [
-      local.backend_port,
-      22
+      80,
+      6514
     ]
-  }
-  allow {
-    protocol = "icmp"
   }
 }
 

--- a/output.tf
+++ b/output.tf
@@ -23,10 +23,10 @@ output bigip_password {
   
 }
 output webapp_1_IP {
-  value = "http://${google_compute_instance.backend[0].network_interface[0].access_config[0].nat_ip}"
+  value = "http://${module.bigip_1.public_addresses[0][1][0]}"
   
 }
 output webapp_2_IP {
-  value = "http://${google_compute_instance.backend[1].network_interface[0].access_config[0].nat_ip}"
+  value = "http://${module.bigip_2.public_addresses[0][1][0]}"
   
 }

--- a/templates/as3.json
+++ b/templates/as3.json
@@ -46,7 +46,8 @@
                   "bigip": "/Common/tcp"
               },
               "virtualAddresses": [
-                  "172.16.0.128"
+                "172.16.100.1",
+                "172.16.100.2"
               ],
               "virtualPort": 6514,
               "snat": "auto"
@@ -62,7 +63,8 @@
                   "bigip": "/Common/tcp"
               },
               "virtualAddresses": [
-                  "172.16.0.129"
+                "172.16.100.1",
+                "172.16.100.2"
               ],
               "virtualPort": 80,
               "snat": "auto"

--- a/templates/do.json
+++ b/templates/do.json
@@ -55,7 +55,10 @@
            "class": "SelfIp",
            "address": "${externalip}/32",
            "vlan": "external",
-           "allowService": "none",
+           "allowService": [
+               "tcp:80",
+               "tcp:6514"
+           ],
            "trafficGroup": "traffic-group-local-only"
       },
       "ext_gw_interface": {

--- a/templates/do.json
+++ b/templates/do.json
@@ -55,10 +55,7 @@
            "class": "SelfIp",
            "address": "${externalip}/32",
            "vlan": "external",
-           "allowService": [
-               "tcp:80",
-               "tcp:6514"
-           ],
+           "allowService": "none",
            "trafficGroup": "traffic-group-local-only"
       },
       "ext_gw_interface": {


### PR DESCRIPTION
Optional - do we want this?

* Use updated CFE role module to better identify custom role by student id
* Remove firewall rule for direct access to backend instances
* Add firewall rule to allow 0.0.0.0/0 to ports 80 and 6514 on BIG-IP external (public) interfaces
* Update DO to 1.20.0
* Update AS3 to add both BIG-IP external VPC private IP addresses
* Modify outputs to use BIG-IP NATd public IP as web app URLs

With this in place, students can curl to external IP addresses and receive content from backend pool.

# Issues
1. not using an Alias IP VIP means the virtual servers are responsive on both BIG-IPs regardless of active/standby state
2. Specifying virtual servers as 2x /32 addresses; can't seem to get quad-zero or a CIDR to work - any ideas @snowblind- @El-Coder @jtylershaw 